### PR TITLE
buttons overlap with add dialog on latest Jenkins weekly

### DIFF
--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceAction/index.jelly
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceAction/index.jelly
@@ -75,7 +75,7 @@
             </j:forEach>
           </table>
           <p:hasAnyPermission permissions="${it.CONFIGURE_AND_DISCONNECT}">
-            <f:bottomButtonBar>
+              <br/>
               <j:if test="${it.maintenanceWindows.size() > 0}">
                 <input type="button" value="${%Edit}" onclick="location.href='config'" class="submit-button primary"/>
               </j:if>
@@ -83,7 +83,6 @@
               <j:if test="${it.maintenanceWindows.size() > 0}">
                 <input type="submit" value="${%Delete selected}" class="submit-button primary"/>
               </j:if>
-            </f:bottomButtonBar>
           </p:hasAnyPermission>
         </f:form>
         <br/>


### PR DESCRIPTION
The buttons fom the Agents maintance overview page stay on top of the
dialog for adding new maintenance windows when running on latest weekly.
Currentl LTS looks good. This is related to the UI changes in core.
Removing the bottombuttonbar fixes the issue

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
