### PR TITLE
timespans for maxwaiting time

### DIFF
--- a/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow.java
+++ b/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow.java
@@ -13,7 +13,6 @@ import java.time.format.DateTimeParseException;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow/config.jelly
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow/config.jelly
@@ -17,7 +17,7 @@
         <f:checkbox default="true" checked="${mw.keepUpWhenActive}"/>
     </f:entry>
     <f:entry field="maxWaitMinutes" title="${%maxWaitMinutes}" help="/plugin/agent-maintenance/help/help-maxWaitMinutes.html">
-        <f:number default="-1" value="${mw.maxWaitMinutes}"/>
+        <f:textbox default="-1" value="${mw.maxWaitMinutes}"/>
     </f:entry>
     <f:entry field="takeOnline" title="${%takeOnline}" help="/plugin/agent-maintenance/help/help-takeOnline.html">
         <f:checkbox default="true" checked="${mw.takeOnline}"/>

--- a/src/main/webapp/help/help-maxWaitMinutes.html
+++ b/src/main/webapp/help/help-maxWaitMinutes.html
@@ -1,2 +1,6 @@
 The time in minutes to wait before aborting running builds.<br/>
-Set to a negative value to wait indefinitely.
+Set to a negative value to wait indefinitely.<br/>
+The format is '&lt;integer>' in minutes, '&lt;integer>&lt;unit>' or a combination of '&lt;integer>&lt;unit>',
+where &lt;unit> is one of 'm' (minutes), 'h' (hours) or 'd' (days).
+Example: '1d 4h 30m' means one day, four hours and 30 minutes which evaluates to 1710 minutes.
+1710 is then the value that will be displayed later.

--- a/src/main/webapp/help/help-maxWaitMinutes_de.html
+++ b/src/main/webapp/help/help-maxWaitMinutes_de.html
@@ -1,2 +1,5 @@
 Die Wartezeit in Minuten, bevor laufende Builds abgebrochen werden.<br/>
-Legen Sie einen negativen Wert fest, um unbegrenzt zu warten.
+Legen Sie einen negativen Wert fest, um unbegrenzt zu warten.<br/>
+Das Format ist '&lt;Ganzzahl>' in Minuten, '&lt;Ganzzahl>&lt;Einheit>' oder eine Kombination aus '&lt;Ganzzahl>&lt;Einheit>',
+wobei &lt;Einheit> entweder 'm' (Minuten), 'h' (Stunden) oder 'd' (Tage) sein muss. Beispiel: '1d 4h 30m' bedeutet einen Tag,
+vier Stunden und 30 Minuten, was 1710 Minuten ergibt. 1710 ist dann der Wert der später angezeigt wird.

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/AgentMaintenanceRetentionStrategyTest.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/AgentMaintenanceRetentionStrategyTest.java
@@ -38,7 +38,7 @@ public class AgentMaintenanceRetentionStrategyTest extends BaseIntegationTest {
             "test",
             true,
             true,
-            5,
+            "5",
             "test",
             null);
     assertThat(agent.toComputer().isAcceptingTasks(), is(true));
@@ -63,7 +63,7 @@ public class AgentMaintenanceRetentionStrategyTest extends BaseIntegationTest {
             "test",
             true,
             false,
-            0,
+            "0",
             "test",
             null);
     String id = mw.getId();
@@ -95,7 +95,7 @@ public class AgentMaintenanceRetentionStrategyTest extends BaseIntegationTest {
             "test",
             true,
             false,
-            0,
+            "0",
             "test",
             null);
     assertThat(agent.toComputer().isOnline(), is(true));
@@ -124,7 +124,7 @@ public class AgentMaintenanceRetentionStrategyTest extends BaseIntegationTest {
             "test",
             false,
             false,
-            0,
+            "0",
             "test",
             null);
     maintenanceHelper.addMaintenanceWindow(agentName, mw);

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/BasePermissionChecks.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/BasePermissionChecks.java
@@ -25,7 +25,7 @@ public abstract class BasePermissionChecks extends PermissionSetup {
 
     MaintenanceWindow maintenanceWindow =
         new MaintenanceWindow(
-            "1970-01-01 11:00", "2099-12-31 23:59", "test", true, true, 10, CONFIGURE, null);
+            "1970-01-01 11:00", "2099-12-31 23:59", "test", true, true, "10", CONFIGURE, null);
     MaintenanceHelper.getInstance().addMaintenanceWindow(agent.getNodeName(), maintenanceWindow);
     return maintenanceWindow;
   }

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/IntegrationTest.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/IntegrationTest.java
@@ -35,7 +35,7 @@ public class IntegrationTest extends BaseIntegationTest {
             "test",
             true,
             true,
-            6,
+            "6",
             "test",
             null);
     String id = mw.getId();
@@ -63,7 +63,7 @@ public class IntegrationTest extends BaseIntegationTest {
             "test",
             true,
             true,
-            2,
+            "2",
             "test",
             null);
     String id = mw.getId();
@@ -93,7 +93,7 @@ public class IntegrationTest extends BaseIntegationTest {
             "test",
             true,
             false,
-            2,
+            "2",
             "test",
             null);
     String id = mw.getId();

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceHelperTest.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceHelperTest.java
@@ -25,7 +25,7 @@ public class MaintenanceHelperTest {
     String agentName = agent.getNodeName();
     Set<MaintenanceWindow> mwSet = helper.getMaintenanceWindows(agentName);
     assertThat(mwSet.size(), is(0));
-    MaintenanceWindow mw = new MaintenanceWindow("1970-01-01 11:00", "2099-12-31 23:59", "test", true, true, 10, "user", null);
+    MaintenanceWindow mw = new MaintenanceWindow("1970-01-01 11:00", "2099-12-31 23:59", "test", true, true, "10", "user", null);
     mwSet.add(mw);
     mwSet = helper.getMaintenanceWindows(agentName);
     assertThat(mwSet.size(), is(1));
@@ -37,7 +37,7 @@ public class MaintenanceHelperTest {
     Set<MaintenanceWindow> mwSet = helper.getMaintenanceWindows(agentName);
     assertThat(helper.getMaintenanceWindows(agentName).size(), is(0));
     assertThat(mwSet.size(), is(0));
-    MaintenanceWindow mw = new MaintenanceWindow("1970-01-01 11:00", "2099-12-31 23:59", "test", true, true, 10, "user", null);
+    MaintenanceWindow mw = new MaintenanceWindow("1970-01-01 11:00", "2099-12-31 23:59", "test", true, true, "10", "user", null);
     mwSet.add(mw);
     mwSet = helper.getMaintenanceWindows(agentName);
     assertThat(mwSet.size(), is(0));

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceNodeListenerTest.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceNodeListenerTest.java
@@ -58,7 +58,7 @@ public class MaintenanceNodeListenerTest {
             "test",
             true,
             true,
-            5,
+            "5",
             "test",
             null);
     maintenanceHelper.addMaintenanceWindow(agent.getNodeName(), mw);
@@ -79,7 +79,7 @@ public class MaintenanceNodeListenerTest {
             "test",
             true,
             true,
-            5,
+            "5",
             "test",
             null);
     maintenanceHelper.addMaintenanceWindow(agent.getNodeName(), mw);

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindowTest.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindowTest.java
@@ -15,43 +15,35 @@ public class MaintenanceWindowTest {
     DescriptorImpl d = new DescriptorImpl();
     assertThat(d.doCheckStartTime("2022-01-01 12:00", "").kind, is(FormValidation.Kind.ERROR));
     assertThat(d.doCheckStartTime("", "2022-01-01 12:00").kind, is(FormValidation.Kind.ERROR));
-    assertThat(
-        d.doCheckStartTime("2022-01-01 12:00", "2022-01-01 10:00").kind,
-        is(FormValidation.Kind.WARNING));
-    assertThat(
-        d.doCheckStartTime("2022-01-01 12:00", "2022-01-02 12:00").kind,
-        is(FormValidation.Kind.OK));
+    assertThat(d.doCheckStartTime("2022-01-01 12:00", "2022-01-01 10:00").kind, is(FormValidation.Kind.WARNING));
+    assertThat(d.doCheckStartTime("2022-01-01 12:00", "2022-01-02 12:00").kind, is(FormValidation.Kind.OK));
+  }
+
+  @Test
+  public void parseWaitingTime() {
+    MaintenanceWindow m1 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "10", "user", "id");
+    assertThat(m1.getMaxWaitMinutes(), is(10));
+    m1 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "10m", "user", "id");
+    assertThat(m1.getMaxWaitMinutes(), is(10));
+    m1 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "1h", "user", "id");
+    assertThat(m1.getMaxWaitMinutes(), is(60));
+    m1 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "2h 10m", "user", "id");
+    assertThat(m1.getMaxWaitMinutes(), is(130));
+    m1 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "1d 1h 30m", "user", "id");
+    assertThat(m1.getMaxWaitMinutes(), is(1530));
   }
 
   @Test
   public void testEquals() {
-    MaintenanceWindow m1 =
-        new MaintenanceWindow(
-            "2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, 0, "user", "id");
-    MaintenanceWindow m2 =
-        new MaintenanceWindow(
-            "2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, 0, "user", "id");
-    MaintenanceWindow m3 =
-        new MaintenanceWindow(
-            "2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, 0, "user2", "id");
-    MaintenanceWindow m4 =
-        new MaintenanceWindow(
-            "2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, 0, "user", "id2");
-    MaintenanceWindow m5 =
-        new MaintenanceWindow(
-            "2022-01-01 12:00", "2022-01-02 11:00", "test", false, false, 350, "user", "id");
-    MaintenanceWindow m6 =
-        new MaintenanceWindow(
-            "2022-01-01 11:00", "2022-01-02 12:00", "test", false, false, 0, "user", "id");
-    MaintenanceWindow m7 =
-        new MaintenanceWindow(
-            "2022-01-01 12:00", "2022-01-02 12:00", "test", true, false, 0, "user", "id");
-    MaintenanceWindow m8 =
-        new MaintenanceWindow(
-            "2022-01-01 12:00", "2022-01-02 12:00", "test", false, true, 0, "user", "id");
-    MaintenanceWindow m9 =
-        new MaintenanceWindow(
-            "2022-01-01 12:00", "2022-01-02 12:00", "test2", false, false, 0, "user", "id");
+    MaintenanceWindow m1 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "0", "user", "id");
+    MaintenanceWindow m2 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "0", "user", "id");
+    MaintenanceWindow m3 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "0", "user2", "id");
+    MaintenanceWindow m4 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, false, "0", "user", "id2");
+    MaintenanceWindow m5 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 11:00", "test", false, false, "350", "user", "id");
+    MaintenanceWindow m6 = new MaintenanceWindow("2022-01-01 11:00", "2022-01-02 12:00", "test", false, false, "0", "user", "id");
+    MaintenanceWindow m7 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", true, false, "0", "user", "id");
+    MaintenanceWindow m8 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test", false, true, "0", "user", "id");
+    MaintenanceWindow m9 = new MaintenanceWindow("2022-01-01 12:00", "2022-01-02 12:00", "test2", false, false, "0", "user", "id");
 
     assertThat(m1.equals(m2), is(true));
     assertThat(m1.equals(m3), is(true));


### PR DESCRIPTION
the waiting time for builds to finish now also accepts timespans in the
format <integer><unit> or a combination or <integer><unit> with <unit> being one of 'd',
'h' or 'm'. E.g. '4h 30m' which is then internally converted to 270 minutes.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
