### PR TITLE
feat: Switch to ionicons-api for global symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .settings
 work
 keystore
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+      <dependency>
+          <groupId>io.jenkins.plugins</groupId>
+          <artifactId>ionicons-api</artifactId>
+          <version>19.v744f3b_2b_b_e4e</version>
+      </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceAction.java
+++ b/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceAction.java
@@ -52,7 +52,7 @@ public class MaintenanceAction implements Action {
   @Override
   public String getIconFileName() {
     if (isVisible()) {
-      return "symbol-build";
+      return "symbol-build-outline plugin-ionicons-api";
     } else {
       return null;
     }

--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceAction/index.jelly
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceAction/index.jelly
@@ -69,7 +69,7 @@
                              asynchronous: false,
                            }
                          ); location.reload(); return false;'>
-                      <l:icon src="symbol-close" class="icon-sm alert-danger" tooltip="Delete this maintenance window"/>
+                      <l:icon src="symbol-close-outline plugin-ionicons-api" class="icon-sm alert-danger" tooltip="Delete this maintenance window"/>
                     </a>
                   </td>
                 </p:hasAnyPermission>

--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceLink/index.jelly
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceLink/index.jelly
@@ -83,7 +83,7 @@
                             location.reload();
                           }; return false'
                     >
-                      <l:icon src="symbol-close" class="icon-sm alert-danger" tooltip="Delete this maintenance windows for ${h.escape(c.displayName)}"/>
+                      <l:icon src="symbol-close-outline plugin-ionicons-api" class="icon-sm alert-danger" tooltip="Delete this maintenance windows for ${h.escape(c.displayName)}"/>
                     </a>
                   </td>
                 </p:hasAnyPermission>


### PR DESCRIPTION
The change proposed makes use of the centralized ionicons API to remove the need to ship symbols on a per-plugin basis or rely on icons shipped by core, that are provided by the library.

cc @mawinter69 