### PR TITLE
[JENKINS-69455] allow to select all, active or inactive maintenance windows

### DIFF
--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceAction/index.jelly
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceAction/index.jelly
@@ -77,6 +77,13 @@
             </j:forEach>
           </table>
           <p:hasAnyPermission permissions="${it.CONFIGURE_AND_DISCONNECT}">
+            <div>
+              Select:
+              <a href="javascript:selectMaintenanceWindows(true, null)">All</a>,
+              <a href="javascript:selectMaintenanceWindows(true, 'active')">Active</a>,
+              <a href="javascript:selectMaintenanceWindows(true, 'inactive')">Inactive</a>,
+              <a href="javascript:selectMaintenanceWindows(false, null)">None</a>
+            </div>
             <f:bottomButtonBar>
               <j:if test="${it.maintenanceWindows.size() > 0}">
                 <input type="button" value="${%Edit}" onclick="location.href='config'" class="submit-button primary"/>

--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceLink/index.jelly
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceLink/index.jelly
@@ -60,9 +60,9 @@
                 <td class="maintenance-row"><nobr>${m.startTime}</nobr></td>
                 <td class="maintenance-row"><nobr>${m.endTime}</nobr></td>
                 <td class="maintenance-row">${m.reason}</td>
-                <td class="maintenance-row" style="text-align:center"><input type="checkbox" disabled="disabled" checked="${m.keepUpWhenActive ? 'true' : null}"/></td>
+                <td class="maintenance-row" style="text-align:center"><input type="checkbox" disabled="true" checked="${m.keepUpWhenActive ? 'true' : null}"/></td>
                 <td class="maintenance-row" style="text-align:right">${m.maxWaitMinutes}</td>
-                <td class="maintenance-row" style="text-align:center"><input type="checkbox" disabled="disabled" checked="${m.takeOnline ? 'true' : null}"/></td>
+                <td class="maintenance-row" style="text-align:center"><input type="checkbox" disabled="true" checked="${m.takeOnline ? 'true' : null}"/></td>
                 <td class="maintenance-row">${m.userid}</td>
                 <p:hasAnyPermission it="${c}" permissions="${a.CONFIGURE_AND_DISCONNECT}">
                   <j:set var="mid" value="${h.escape(m.id)}"/>
@@ -91,6 +91,13 @@
             </j:forEach>
           </j:forEach>
         </table>
+        <div>
+          Select:
+          <a href="javascript:selectMaintenanceWindows(true, null)">All</a>,
+          <a href="javascript:selectMaintenanceWindows(true, 'active')">Active</a>,
+          <a href="javascript:selectMaintenanceWindows(true, 'inactive')">Inactive</a>,
+          <a href="javascript:selectMaintenanceWindows(false, null)">None</a>
+        </div>
         <j:if test="${it.hasError()}">
           <br/>
           <div class="error">

--- a/src/main/webapp/js/agent-maintenance.js
+++ b/src/main/webapp/js/agent-maintenance.js
@@ -16,3 +16,16 @@ function cancelAdd(event) {
         closeForm();
     }
 }
+
+var selectMaintenanceWindows = function(toggle, className) {
+    let table = document.getElementById("maintenance-table")
+    let inputs = table.getElementsByTagName("input");
+    for(var i=0; i<inputs.length; i++) {
+        if(inputs[i].type === "checkbox" && !inputs[i].disabled) {
+            let tr = findAncestor(inputs[i], "TR")
+            if (className == null || tr != null && tr.classList.contains(className)) {
+                inputs[i].checked = toggle;
+            }
+        }
+    }
+};


### PR DESCRIPTION
When maintenance windows can be removed because the planned activity was
finished earlier and many maintenance windows exists it is quite painful
to click all the checkboxes.
This change will add clickable texts below the table so that one can
select, all, active inactive and no maintenance windows

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
