### PR TITLE
Use ionicons-api version provided by bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-2.346.x</artifactId>
-            <version>1595.v8c71c13cc3a_9</version>
+            <version>1678.vc1feb_6a_3c0f1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -62,7 +62,6 @@
       <dependency>
           <groupId>io.jenkins.plugins</groupId>
           <artifactId>ionicons-api</artifactId>
-          <version>19.v744f3b_2b_b_e4e</version>
       </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
I'm not aware of any version conflict, but if there's one, a release would resolve it.

cc @jenkinsci/agent-maintenance-plugin-developers 

Closes #63 
Closes #60 