### PR TITLE
stabilize and speed up tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
       <version>109.vac7845f10470</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>mock-security-realm</artifactId>
+          <version>1.6</version>
+          <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
@@ -106,7 +112,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>1C</forkCount>
+          <forkCount>0.5C</forkCount>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/BaseIntegationTest.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/BaseIntegationTest.java
@@ -39,6 +39,7 @@ public abstract class BaseIntegationTest {
     LocalDateTime timeout = LocalDateTime.now().plusMinutes(4);
     while (agent.getChannel() != null) {
       TimeUnit.SECONDS.sleep(10);
+      triggerCheckCycle(agent);
       LocalDateTime now = LocalDateTime.now();
       if (now.isAfter(timeout)) {
         String active = "unknown"; 
@@ -47,6 +48,13 @@ public abstract class BaseIntegationTest {
         }
         throw new Exception("Agent did not disconnect within 4 minutes. Active: " + active);
       }
+    }
+  }
+
+  protected void triggerCheckCycle(Slave agent) {
+    SlaveComputer computer = (SlaveComputer) agent.toComputer();
+    if (computer != null) {
+      computer.getRetentionStrategy().check(computer);
     }
   }
 }

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/BasePermissionChecks.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/BasePermissionChecks.java
@@ -21,11 +21,11 @@ public abstract class BasePermissionChecks extends PermissionSetup {
   protected static MaintenanceWindow maintenanceWindowToDelete;
   protected static String agentMaintenanceUrl;
 
-  protected static MaintenanceWindow createMaintenanceWindow(Slave agent) throws IOException {
+  protected static MaintenanceWindow createMaintenanceWindow(Slave agent, String reason) throws IOException {
 
     MaintenanceWindow maintenanceWindow =
         new MaintenanceWindow(
-            "1970-01-01 11:00", "2099-12-31 23:59", "test", true, true, "10", CONFIGURE, null);
+            "1970-01-01 11:00", "2099-12-31 23:59", reason, true, true, "10", CONFIGURE, null);
     MaintenanceHelper.getInstance().addMaintenanceWindow(agent.getNodeName(), maintenanceWindow);
     return maintenanceWindow;
   }
@@ -42,24 +42,24 @@ public abstract class BasePermissionChecks extends PermissionSetup {
     agent.setRetentionStrategy(new AgentMaintenanceRetentionStrategy(new Demand(1, 2)));
     agentRestricted.setRetentionStrategy(new AgentMaintenanceRetentionStrategy(new Always()));
 
-    maintenanceWindow = createMaintenanceWindow(agent);
+    maintenanceWindow = createMaintenanceWindow(agent, "test");
 
     maintenanceId = maintenanceWindow.getId();
     agentMaintenanceUrl = agent.toComputer().getUrl() + "maintenanceWindows";
 
-    maintenanceWindowRestricted = createMaintenanceWindow(agentRestricted);
+    maintenanceWindowRestricted = createMaintenanceWindow(agentRestricted, "test Restricted");
     maintenanceIdRestricted = maintenanceWindowRestricted.getId();
 
-    maintenanceWindowToDelete = createMaintenanceWindow(agent);
+    maintenanceWindowToDelete = createMaintenanceWindow(agent, "test to delete");
     maintenanceIdToDelete = maintenanceWindowToDelete.getId();
 
     AuthorizationMatrixNodeProperty nodeProp = new AuthorizationMatrixNodeProperty();
     AuthorizationMatrixNodeProperty nodePropRestricted = new AuthorizationMatrixNodeProperty();
 
     // System read and computer configure on agent, but not on agentRestricted
-    nodeProp.add(Computer.CONFIGURE, CONFIGURE);
-    nodeProp.add(Computer.DISCONNECT, DISCONNECT);
-    nodePropRestricted.add(Computer.EXTENDED_READ, CONFIGURE);
+    nodeProp.add(Computer.CONFIGURE, configure);
+    nodeProp.add(Computer.DISCONNECT, disconnect);
+    nodePropRestricted.add(Computer.EXTENDED_READ, configure);
 
     agent.getNodeProperties().add(nodeProp);
     agentRestricted.getNodeProperties().add(nodePropRestricted);

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/PermissionSetup.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/PermissionSetup.java
@@ -4,6 +4,8 @@ import hudson.model.Computer;
 import hudson.security.HudsonPrivateSecurityRealm;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.matrixauth.AuthorizationType;
+import org.jenkinsci.plugins.matrixauth.PermissionEntry;
 import org.junit.Before;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -19,6 +21,9 @@ public abstract class PermissionSetup {
   protected static final String USER = "user";
   protected static final String MANAGE = "manage";
   protected static final String ADMIN = "admin";
+
+  protected static final PermissionEntry configure = new PermissionEntry(AuthorizationType.USER, CONFIGURE);
+  protected static final PermissionEntry disconnect = new PermissionEntry(AuthorizationType.USER, DISCONNECT);
 
   /**
    * Setup tests.
@@ -38,12 +43,12 @@ public abstract class PermissionSetup {
     ProjectMatrixAuthorizationStrategy matrixAuth = new ProjectMatrixAuthorizationStrategy();
 
     // System read and computer configure on agent, but not on agentRestricted
-    matrixAuth.add(Jenkins.READ, CONFIGURE);
-    matrixAuth.add(Jenkins.SYSTEM_READ, CONFIGURE);
+    matrixAuth.add(Jenkins.READ, configure);
+    matrixAuth.add(Jenkins.SYSTEM_READ, configure);
 
     // System read and computer configure on agent, but not on agentRestricted
-    matrixAuth.add(Jenkins.READ, DISCONNECT);
-    matrixAuth.add(Jenkins.SYSTEM_READ, DISCONNECT);
+    matrixAuth.add(Jenkins.READ, disconnect);
+    matrixAuth.add(Jenkins.SYSTEM_READ, disconnect);
 
     // system manage
     matrixAuth.add(Jenkins.READ, MANAGE);


### PR DESCRIPTION
it is not guarantueed that the check method of the retentionstrategy is called every minute. Most of the time it is only called every 2 minutes. This slows down the tests and when the timing is too tight can lead to test failures.
When waiting for things (builds, maintenance start or end) trigger the call to the check method manually every 10s this allows to set shorter waiting times in the tests.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
