### PR TITLE
dynamically update the offline cause data

### DIFF
--- a/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/AgentMaintenanceRetentionStrategy.java
+++ b/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/AgentMaintenanceRetentionStrategy.java
@@ -77,16 +77,16 @@ public class AgentMaintenanceRetentionStrategy extends RetentionStrategy<SlaveCo
                 public void run() {
                   LOGGER.log(Level.INFO, "Disconnecting agent {0} as it was idle when " + "maintenance window started.",
                       new Object[] { c.getName() });
-                  c.disconnect(maintenance.getOfflineCause());
+                  c.disconnect(maintenance.getOfflineCause(c.getName()));
                 }
               });
             }
           } else {
-            if (maintenance.isAborted()) {
+            if (maintenance.buildsHaveBeenAborted()) {
               LOGGER.log(Level.INFO,
                   "Disconnecting agent {0} as it has finished its scheduled uptime and max " + "waiting time for builds to finish is over",
                   new Object[] { c.getName() });
-              c.disconnect(maintenance.getOfflineCause());
+              c.disconnect(maintenance.getOfflineCause(c.getName()));
             } else {
               LOGGER.log(Level.INFO, "Aborting running builds on agent {0} as it has finished its scheduled uptime "
                   + "and max waiting time for builds to finish is over", new Object[] { c.getName() });
@@ -99,12 +99,12 @@ public class AgentMaintenanceRetentionStrategy extends RetentionStrategy<SlaveCo
             }
           }
         } else {
-          if (maintenance.isAborted()) {
+          if (maintenance.buildsHaveBeenAborted()) {
             // no need to get the queue lock as the user
             // has selected the break builds
             // option!
             LOGGER.log(Level.INFO, "Disconnecting agent {0} as it has finished its scheduled uptime", new Object[] { c.getName() });
-            c.disconnect(maintenance.getOfflineCause());
+            c.disconnect(maintenance.getOfflineCause(c.getName()));
           } else {
             LOGGER.log(Level.INFO, "Aborting running builds on agent {0} as it has finished its scheduled uptime",
                 new Object[] { c.getName() });

--- a/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceHelper.java
+++ b/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceHelper.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -124,6 +125,25 @@ public class MaintenanceHelper {
       }
     }
     return list;
+  }
+
+  /**
+   * Returns the maintenance window with the given id that is connected to the given computer.
+   *
+   * @param computerName name of the computer
+   * @param id id of the maintenance
+   * @return The maintenance window or null if not found
+   */
+  @CheckForNull
+  public MaintenanceWindow getMaintenanceWindow(String computerName, String id) {
+    SortedSet<MaintenanceWindow> mwSet = null;
+    try {
+      mwSet = getMaintenanceWindows(computerName);
+    } catch (IOException e) {
+      return null;
+    }
+    Optional<MaintenanceWindow> mw = mwSet.stream().filter(w -> w.getId().equals(id)).findFirst();
+    return mw.orElse(null);
   }
 
   /**

--- a/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause.java
+++ b/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause.java
@@ -5,25 +5,46 @@ import hudson.slaves.OfflineCause;
 /** Offline cause because of a maintenance. */
 public class MaintenanceOfflineCause extends OfflineCause {
 
-  private final MaintenanceWindow maintenanceWindow;
+  private final String maintenanceId;
+  private final String computerName;
 
-  public MaintenanceOfflineCause(MaintenanceWindow maintenanceWindow) {
-    this.maintenanceWindow = maintenanceWindow;
+  public MaintenanceOfflineCause(String maintenanceId, String computerName) {
+    this.maintenanceId = maintenanceId;
+    this.computerName = computerName;
   }
 
+  private MaintenanceWindow getMaintenanceWindow() {
+    return MaintenanceHelper.getInstance().getMaintenanceWindow(computerName, maintenanceId);
+  }
   public String getStartTime() {
+    MaintenanceWindow maintenanceWindow = getMaintenanceWindow();
+    if (maintenanceWindow == null) {
+      return "not found";
+    }
     return maintenanceWindow.getStartTime();
   }
 
   public String getEndTime() {
+    MaintenanceWindow maintenanceWindow = getMaintenanceWindow();
+    if (maintenanceWindow == null) {
+      return "not found";
+    }
     return maintenanceWindow.getEndTime();
   }
 
   public String getReason() {
+    MaintenanceWindow maintenanceWindow = getMaintenanceWindow();
+    if (maintenanceWindow == null) {
+      return "not found";
+    }
     return maintenanceWindow.getReason();
   }
 
   public boolean isTakeOnline() {
+    MaintenanceWindow maintenanceWindow = getMaintenanceWindow();
+    if (maintenanceWindow == null) {
+      return true;
+    }
     return maintenanceWindow.isTakeOnline();
   }
 

--- a/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause.java
+++ b/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause.java
@@ -5,46 +5,37 @@ import hudson.slaves.OfflineCause;
 /** Offline cause because of a maintenance. */
 public class MaintenanceOfflineCause extends OfflineCause {
 
-  private final String maintenanceId;
+  private MaintenanceWindow maintenanceWindow;
   private final String computerName;
 
-  public MaintenanceOfflineCause(String maintenanceId, String computerName) {
-    this.maintenanceId = maintenanceId;
+  public MaintenanceOfflineCause(MaintenanceWindow maintenanceWindow, String computerName) {
+    this.maintenanceWindow = maintenanceWindow;
     this.computerName = computerName;
   }
 
-  private MaintenanceWindow getMaintenanceWindow() {
-    return MaintenanceHelper.getInstance().getMaintenanceWindow(computerName, maintenanceId);
-  }
-  public String getStartTime() {
-    MaintenanceWindow maintenanceWindow = getMaintenanceWindow();
-    if (maintenanceWindow == null) {
-      return "not found";
+  private void updateMaintenanceWindow() {
+    MaintenanceWindow newMaintenanceWindow = MaintenanceHelper.getInstance().getMaintenanceWindow(computerName, maintenanceWindow.getId());
+    if (newMaintenanceWindow != null) {
+      maintenanceWindow = newMaintenanceWindow;
     }
+  }
+
+  public String getStartTime() {
+    updateMaintenanceWindow();
     return maintenanceWindow.getStartTime();
   }
 
   public String getEndTime() {
-    MaintenanceWindow maintenanceWindow = getMaintenanceWindow();
-    if (maintenanceWindow == null) {
-      return "not found";
-    }
+    updateMaintenanceWindow();
     return maintenanceWindow.getEndTime();
   }
 
   public String getReason() {
-    MaintenanceWindow maintenanceWindow = getMaintenanceWindow();
-    if (maintenanceWindow == null) {
-      return "not found";
-    }
+    updateMaintenanceWindow();
     return maintenanceWindow.getReason();
   }
 
   public boolean isTakeOnline() {
-    MaintenanceWindow maintenanceWindow = getMaintenanceWindow();
-    if (maintenanceWindow == null) {
-      return true;
-    }
     return maintenanceWindow.isTakeOnline();
   }
 

--- a/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow.java
+++ b/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow.java
@@ -206,7 +206,7 @@ public class MaintenanceWindow extends AbstractDescribableImpl<MaintenanceWindow
   }
 
   public OfflineCause getOfflineCause(String computerName) {
-    return new MaintenanceOfflineCause(this.id, computerName);
+    return new MaintenanceOfflineCause(this, computerName);
   }
 
   /** Descriptor for UI only. */

--- a/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow.java
+++ b/src/main/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow.java
@@ -141,7 +141,7 @@ public class MaintenanceWindow extends AbstractDescribableImpl<MaintenanceWindow
     return keepUpWhenActive;
   }
 
-  public boolean isAborted() {
+  public boolean buildsHaveBeenAborted() {
     return aborted;
   }
 
@@ -205,8 +205,8 @@ public class MaintenanceWindow extends AbstractDescribableImpl<MaintenanceWindow
     return now.isAfter(endDateTime);
   }
 
-  public OfflineCause getOfflineCause() {
-    return new MaintenanceOfflineCause(this);
+  public OfflineCause getOfflineCause(String computerName) {
+    return new MaintenanceOfflineCause(this.id, computerName);
   }
 
   /** Descriptor for UI only. */

--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause/cause.jelly
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause/cause.jelly
@@ -5,9 +5,14 @@
       <i:formatDate value="${it.time}" type="both" dateStyle="medium" timeStyle="medium"/>
     </div>
     <div class="message">
-      ${%Start Time} : ${it.startTime}<br/>
-      ${%End Time} : ${it.endTime}<br/>
-      ${%Reason} : ${it.reason}
+      <j:if test="${it.startTime != 'not found'}">
+        ${%Start Time} : ${it.startTime}<br/>
+        ${%End Time} : ${it.endTime}<br/>
+        ${%Reason} : ${it.reason}
+      </j:if>
+      <j:if test="${it.startTime == 'not found'}">
+        ${%maintenanceover}
+      </j:if>
     </div>
   </div>
 </j:jelly>

--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause/cause.properties
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause/cause.properties
@@ -1,0 +1,1 @@
+maintenanceover=The maintenance window was not found. Probably it has just ended.

--- a/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause/cause_de.properties
+++ b/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCause/cause_de.properties
@@ -1,3 +1,4 @@
+maintenanceover=Das Wartungsfenster wurde nicht gefunden. Wahrscheinlich ist es gerade zu Ende gegangen.
 Start\ Time=Startzeit
 End\ Time=Endzeit
 Reason=Grund

--- a/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCauseTest.java
+++ b/src/test/java/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceOfflineCauseTest.java
@@ -1,0 +1,74 @@
+package com.sap.prd.jenkins.plugins.agent_maintenance;
+
+import static com.sap.prd.jenkins.plugins.agent_maintenance.MaintenanceWindow.DATE_FORMATTER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import hudson.model.Slave;
+import hudson.slaves.RetentionStrategy;
+import java.time.LocalDateTime;
+import java.util.SortedSet;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/** Tests the offline cause. */
+public class MaintenanceOfflineCauseTest {
+  @Rule
+  public JenkinsRule rule = new JenkinsRule();
+
+  private MaintenanceHelper maintenanceHelper = MaintenanceHelper.getInstance();
+  private Slave agent;
+
+  /**
+   * Setup agent.
+   *
+   * @throws Exception in case of an error
+   */
+  @Before
+  public void setup() throws Exception {
+    agent = rule.createOnlineSlave();
+    AgentMaintenanceRetentionStrategy strategy =
+        new AgentMaintenanceRetentionStrategy(new RetentionStrategy.Always());
+    agent.setRetentionStrategy(strategy);
+  }
+
+  @Test
+  public void offlineCauseIsUpdated() throws Exception {
+    setup();
+    LocalDateTime start = LocalDateTime.now().minusMinutes(1);
+    LocalDateTime end = start.plusMinutes(5);
+    MaintenanceWindow mw =
+        new MaintenanceWindow(
+            start.format(DATE_FORMATTER),
+            end.format(DATE_FORMATTER),
+            "test",
+            true,
+            true,
+            "5",
+            "test",
+            null);
+    maintenanceHelper.addMaintenanceWindow(agent.getNodeName(), mw);
+    MaintenanceOfflineCause moc = (MaintenanceOfflineCause) mw.getOfflineCause(agent.getNodeName());
+    assertThat(moc.getReason(), is("test"));
+    MaintenanceWindow updated =
+        new MaintenanceWindow(
+            start.format(DATE_FORMATTER),
+            end.format(DATE_FORMATTER),
+            "changed",
+            true,
+            true,
+            "5",
+            "test",
+            mw.getId());
+
+    SortedSet<MaintenanceWindow> mwlist = MaintenanceHelper.getInstance().getMaintenanceWindows(agent.getNodeName());
+    synchronized (mwlist) {
+      mwlist.clear();
+      mwlist.add(updated);
+      MaintenanceHelper.getInstance().saveMaintenanceWindows(agent.getNodeName(), mwlist);
+    }
+    assertThat(moc.getReason(), is("changed"));
+  }
+}


### PR DESCRIPTION
when an agent is offline the message shows start time, end time and reason. Whenever someone modifies the corresponding maintenance window, the message was not updated.

This change will dynamically read the corresponding maintenance window to show the latest data.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
